### PR TITLE
Ei/daysLeft

### DIFF
--- a/tasktabs/src/components/shareUsers.tsx
+++ b/tasktabs/src/components/shareUsers.tsx
@@ -9,13 +9,6 @@ const SharedWithTab = styled.div`
     width: 100%;
 `;
 
-const LabelTab = styled.div`
-    display: flex;
-    flex-direction: row;
-    border: solid 2px black;
-    border-bottom: none;
-`;
-
 const UserText = styled.div`
     font-size: 32px;
 `;
@@ -78,29 +71,19 @@ export class ShareUsers extends React.Component<ShareUserProps> {
         });
 
         return (
-            <>
-                <LabelTab>
-                    <OwnerBox>
-                        <LabelText>
-                            Owner
-                        </LabelText>
-                    </OwnerBox>
-                    <SharedUserBox>
-                        <LabelText>
-                            Shared With
-                        </LabelText>
-                    </SharedUserBox>
-                </LabelTab>
                 <SharedWithTab>
                     <OwnerBox>
+                        <LabelText> Owner </LabelText>
                         <UserText> {this.owner.name} </UserText>
                     </OwnerBox>
+                    <SharedUserBox>
+                        <LabelText> Shared With </LabelText>
+                    </SharedUserBox>
                     {sharedArray}
                     <AddUserButton>
                         <ButtonText> + </ButtonText>
                     </AddUserButton>
                 </SharedWithTab>
-            </>
         )
     }
 }

--- a/tasktabs/src/components/taskView.tsx
+++ b/tasktabs/src/components/taskView.tsx
@@ -94,7 +94,7 @@ const DescText = styled.textarea`
 
 const HistoryButton = styled.button`
     width: 207px;
-    height: 100px;
+    height: 125px;
     bottom: 3px;
     right: 408px;
 `;
@@ -222,10 +222,20 @@ export class TaskView extends React.Component<TaskViewProps>{
     //Checks how many days are left and changes message accordingly
     daysLeftCheck = () => {
         if(this.daysLeft >= 0) {
-            this.displayedDaysLeft = this.daysLeft + " Days Left!";
+            if(this.daysLeft == 1) {
+                this.displayedDaysLeft = this.daysLeft + " Day Left!";
+            }
+            else {
+                this.displayedDaysLeft = this.daysLeft + " Days Left!";
+            }
         }
         else {
-            this.displayedDaysLeft = Math.abs(this.daysLeft) + " Days Late!";
+            if(this.daysLeft == -1) {
+                this.displayedDaysLeft = Math.abs(this.daysLeft) + " Day Late!";
+            }
+            else {
+                this.displayedDaysLeft = Math.abs(this.daysLeft) + " Days Late!";
+            }    
         }
     }
 

--- a/tasktabs/src/components/taskView.tsx
+++ b/tasktabs/src/components/taskView.tsx
@@ -12,7 +12,7 @@ interface ColumnProps {
 };
 
 // The column will remain at its maximum height, so if the window
-// is shrunk , a scrollbar will remain unless the height of the column 
+// is shrunk , a scrollbar will remain unless the height of the column
 // is changed to the window height
 const Column = styled.div`
     display: flex;
@@ -141,6 +141,7 @@ export class TaskView extends React.Component<TaskViewProps>{
     displayedDueDate: string;
     today: Date;
     daysLeft: number;
+    displayedDaysLeft: string;
     displayedStartDate: string;
     status: string;
     statusOptions: Options[];
@@ -155,6 +156,7 @@ export class TaskView extends React.Component<TaskViewProps>{
 
         this.today = new Date();
         this.daysLeft = 0;
+        this.displayedDaysLeft = "0 Days Left!";
         this.displayedDueDate = "1/1/1900";
         this.displayedStartDate = "1/1/1900";
 
@@ -217,6 +219,16 @@ export class TaskView extends React.Component<TaskViewProps>{
         this.displayedStartDate = month + "/" + day + "/" + year;
     }
 
+    //Checks how many days are left and changes message accordingly
+    daysLeftCheck = () => {
+        if(this.daysLeft >= 0) {
+            this.displayedDaysLeft = this.daysLeft + " Days Left!";
+        }
+        else {
+            this.displayedDaysLeft = Math.abs(this.daysLeft) + " Days Late!";
+        }
+    }
+
     updateDimensions = () => {
         this.setState({ width: window.innerWidth, height: window.innerHeight });
     };
@@ -255,6 +267,7 @@ export class TaskView extends React.Component<TaskViewProps>{
         this.calculateDaysLeft();
         this.dueDateString();
         this.startDateString();
+        this.daysLeftCheck();
         const name = this.displayName();
         const height = this.checkHeight();
         const width = this.checkWidth();
@@ -277,7 +290,7 @@ export class TaskView extends React.Component<TaskViewProps>{
                             <LabelText>{this.displayedDueDate}</LabelText>
                         </CalendarButton>
                     </LabelText>
-                    <LabelText> {this.daysLeft} Days Left! </LabelText>
+                    <LabelText> {this.displayedDaysLeft} </LabelText>
                     <Row>
                         <StatusDropdown taskStatus={this.status} statusList={this.statusOptions} />
                         <AssignedDropdown assignedState={this.props.assignee} sharedUsers={this.sharedUsers} owner={this.owner} />


### PR DESCRIPTION
A quick PR in order to have the days left message to change depending on if there is 1 day(as opposed to 1 days ) or if the due date has already passed (so there are no negative days left). 

Also I did a quick fix to the sharedUsers tab because I noticed only while doing this that the formatting for that changed a bit(mainly for the label). The "Shared With" label isn't quite where I want it to be, but I don't really wanna sit down and play around with specific page formatting because we'll be more formally styling up the page later. 

![image](https://user-images.githubusercontent.com/56561909/77591484-6bd62e00-6ec6-11ea-9a99-412e93ed46e5.png)

Also sorry about the weird commits, I keep playing around stupidly using the Atom Git extension and then I make a mistake and don't notice it until after I pushed my updates. I'll fix that bad habit and try not to do that again in the future.
