### PR TITLE
Don't get the project id if no result is returned.

### DIFF
--- a/api/controllers/basePrivilegeRequiredController.ts
+++ b/api/controllers/basePrivilegeRequiredController.ts
@@ -22,7 +22,9 @@ export class BasePrivilegeRequiredController{
                 throw new Error(err);
             }
 
-            projectId = task.get("projectId");
+            if (task){
+                projectId = task.get("projectId");
+            }
         });
 
         // see if the current user can view tasks in this project


### PR DESCRIPTION
Hopefully will not crash the backend anymore.